### PR TITLE
Solved second round of bugs for the framework :

### DIFF
--- a/event_queues/event_queue.c
+++ b/event_queues/event_queue.c
@@ -22,7 +22,7 @@ void destroy_node(struct event_node *node) {
     free(node) ;
 }
 
-void *enqueue_event(struct event_queue *queue, struct event *event) {
+void enqueue_event(struct event_queue *queue, struct event *event) {
 
     struct event_node *node = queue->firstNode ;
 

--- a/event_queues/event_queue.h
+++ b/event_queues/event_queue.h
@@ -14,7 +14,7 @@ typedef struct event_queue {
     struct event_node *firstNode ;
 } event_queue ;
 
-void *enqueue_event(struct event_queue *queue, struct event *event) ;
+void enqueue_event(struct event_queue *queue, struct event *event) ;
 
 struct event *dequeue_event(struct event_queue *queue) ;
 

--- a/events/event.c
+++ b/events/event.c
@@ -23,9 +23,9 @@ event *createEvent(double time, void (*change_state_func)(simulation *sim), void
 void consumeEvent(struct event *ev, struct simulation *sim) {
 
     if (ev->time <= sim->simEnd) {
+        sim->clock = ev->time ;
         ev->change_sim_state(sim) ;
         ev->schedule_next_event(sim) ;
-        sim->clock = ev->time ;
     }
 
     free(ev) ;

--- a/simulation/simulation.c
+++ b/simulation/simulation.c
@@ -101,14 +101,14 @@ struct simulation *create_simulation(int state_size, int event_queues, double si
 
     struct queue_list *actual = list_head;
 
-    for(int i = 0 ; i < state_size ; i++) {
+    for(int i = 0 ; i < event_queues ; i++) {
         if((actual->queue = create_queue()) == NULL) {
             destroy_simulation(sim) ;
 
             return NULL ;
         }
 
-        if (i == state_size-1) {
+        if (i == event_queues-1) {
             actual->next = NULL ;
         } else {
             struct queue_list *newL ;


### PR DESCRIPTION
 - event.c : put clock update before event consumption, because the event should change the state of the system at the time it happens, not before.
 - simulation.c : resolved a typo on lines 104 and 111, now event_queues is used instead of state_size
 - event_queue.c, event_queue.h : function enqueue_event now returns void, not void * (it was a typo, the function has no reason to return a pointer)